### PR TITLE
Add Google login page and Supabase client

### DIFF
--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey)

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,0 +1,23 @@
+import { supabase } from '@/lib/supabaseClient'
+import { LoginForm } from '@/components/login-form'
+import { Button } from '@/components/ui/button'
+
+export default function LoginPage() {
+  const handleGoogleLogin = async () => {
+    await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: { redirectTo: `${window.location.origin}/protected` },
+    })
+  }
+
+  return (
+    <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10">
+      <div className="w-full max-w-sm space-y-4">
+        <LoginForm />
+        <Button className="w-full" onClick={handleGoogleLogin}>
+          Sign in with Google
+        </Button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add a simple Supabase client in `lib/supabaseClient.ts`
- implement a new `/pages/login.tsx` page with a Google login button

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685bc664c698832980939aaccc9939f1